### PR TITLE
fix OpenJPEG on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,11 @@ endif()
 
 magick_find_delegate(DELEGATE JBIG_DELEGATE NAME JBIG DEFAULT TRUE)
 magick_find_delegate(DELEGATE JPEG_DELEGATE NAME JPEG DEFAULT TRUE)
-magick_find_delegate(DELEGATE LIBOPENJP2_DELEGATE NAME OpenJPEG DEFAULT TRUE)
+magick_find_delegate(DELEGATE LIBOPENJP2_DELEGATE NAME OpenJPEG DEFAULT TRUE TARGETS openjp2)
+# OpenJPEG has an ancient CMake that wasn't fixed until 2.5
+if (OPENJPEG_INCLUDE_DIRS)
+  include_directories(${OPENJPEG_INCLUDE_DIRS})
+endif()
 magick_find_delegate(DELEGATE OPENEXR_DELEGATE NAME OpenEXR DEFAULT TRUE)
 magick_find_delegate(DELEGATE PNG_DELEGATE NAME PNG DEFAULT TRUE)
 magick_find_delegate(DELEGATE RSVG_DELEGATE NAME Rsvg DEFAULT TRUE)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/ImageMagick/pulls) open
- [x] I have verified that I am following the existing coding patterns and practices as demonstrated in the repository.

### Description
<!-- A description of the changes proposed in the pull-request
     If you want to change something in the 'www' or 'ImageMagick' folder please
     open an issue here instead: https://github.com/ImageMagick/Website -->

<!-- Thanks for contributing to ImageMagick! -->

Fix importing the system `OpenJPEG` on Linux - it has an ancient `CMake` that does not export `INTERFACE_INCLUDE_DIRECTORIES`
